### PR TITLE
CHUNK SIZE过大导致上传失败

### DIFF
--- a/bilibili.py
+++ b/bilibili.py
@@ -108,7 +108,7 @@ class Bilibili:
         filename = os.path.basename(filepath)
         with open(filepath, 'rb') as f:
             # 1M = 1024K = 1024 * 1024B
-            CHUNK_SIZE = 10 * 1024 * 1024
+            CHUNK_SIZE = 7 * 1024 * 1024
             filesize = os.path.getsize(filepath)
             chunks_num = math.ceil(filesize / CHUNK_SIZE)
             chunks_index = 0


### PR DESCRIPTION
不知道b站判定这个size的依据是什么？反正这里试了下，7是可以成功上传的，8就过大了。。。原来的10更不用说了太大了。可能b站最近改了分块大小