### PR TITLE
添加投稿描述长度限制

### DIFF
--- a/bilibiliupload/bilibili.py
+++ b/bilibiliupload/bilibili.py
@@ -181,7 +181,7 @@ class Bilibili:
         :param tag: video's tag
         :type tag: list<str>
         :param desc: video's description
-        :type desc: str
+        :type desc: str 注: 最大长度 250，超过长度B站服务器会报错
         :param dtime: (optional) publish date timestamp (10 digits Unix timestamp e.g. 1551533438)
         :type dtime: int
         :param source: (optional) 转载地址


### PR DESCRIPTION
该程序是模拟的APP端上传，上传的时候投稿描述不能超过250的长度，否则会报错
`{"code":21052,"message":"稿件描述长度太长，已超过限制","ttl":1}`