### PR TITLE
上传文件前检查字符串长度限制

### DIFF
--- a/bilibiliupload/bilibili.py
+++ b/bilibiliupload/bilibili.py
@@ -204,6 +204,10 @@ class Bilibili:
         :type max_retry: int
         """
 
+        assert len(title) <= 80, "标题长度超过80字"
+        assert len(desc) <= 250, "视频描述超过250字"
+        assert len(source) <= 200, "转载地址长度超过200字"
+        
         self.session.headers['Content-Type'] = 'application/json; charset=utf-8'
         if not isinstance(parts, list):
             parts = [parts]

--- a/bilibiliupload/bilibili.py
+++ b/bilibiliupload/bilibili.py
@@ -204,9 +204,12 @@ class Bilibili:
         :type max_retry: int
         """
 
-        assert len(title) <= 80, "标题长度超过80字"
-        assert len(desc) <= 250, "视频描述超过250字"
-        assert len(source) <= 200, "转载地址长度超过200字"
+        if len(title) > 80:
+            raise Exception("标题长度超过80字")
+        if len(desc) > 250:
+            raise Exception("视频描述超过250字")
+        if len(source) > 200:
+            raise Exception("转载地址长度超过200字")
         
         self.session.headers['Content-Type'] = 'application/json; charset=utf-8'
         if not isinstance(parts, list):

--- a/bilibiliupload/bilibili.py
+++ b/bilibiliupload/bilibili.py
@@ -30,7 +30,7 @@ class VideoPart:
         self.desc = desc
 
     def __repr__(self):
-        return '<{clazz}, path: {path}, title: {title}, desc: {desc}>'.format(clazz=self.__class__.__name__, path=path, title=title, desc=desc)
+        return '<{clazz}, path: {path}, title: {title}, desc: {desc}>'.format(clazz=self.__class__.__name__, path=self.path, title=self.title, desc=self.desc)
 
 class Bilibili:
     def __init__(self, cookie=None):


### PR DESCRIPTION
避免视频文件上传后因为文字超限导致上传失败